### PR TITLE
feat: Add option to exclude third-party packages

### DIFF
--- a/pybundler/dependency_bundler.py
+++ b/pybundler/dependency_bundler.py
@@ -99,13 +99,14 @@ class DependencyBundler:
     """
     MAX_PROCESSED = 1000
 
-    def __init__(self):
+    def __init__(self, exclude_third_party=False):
         """
         Initializes the DependencyBundler, setting up the state for a new analysis run.
         """
         self.processed_object_ids = set()
         self.collected_source = {}
         self.objects_to_process = deque()
+        self.exclude_third_party = exclude_third_party
 
     def find_and_queue_dependencies(self, obj, obj_globals):
         """
@@ -182,7 +183,8 @@ class DependencyBundler:
             log.debug("Error getting module for dependency %s: %s", dep_obj, e)
             return
 
-        if not should_include_module(module, exclude_list=EXCLUDE_PACKAGES):
+        if not should_include_module(module, exclude_list=EXCLUDE_PACKAGES,
+                                     exclude_third_party=self.exclude_third_party):
             return
 
         source_code, src_file, start_line = get_object_source(dep_obj)

--- a/pybundler/main.py
+++ b/pybundler/main.py
@@ -43,6 +43,11 @@ def main():
         choices=["debug", "info", "warning", "error", "critical"],
         help="Set the logging level (default: info)."
     )
+    parser.add_argument(
+        "--no-third-party",
+        action="store_true",
+        help="If set, third-party packages from site-packages will not be included in the bundle."
+    )
     args = parser.parse_args()
 
     setup_logging(args.log_level)
@@ -58,7 +63,7 @@ def main():
         sys.exit(1)
 
     # 3. *** Run the core analysis using the dedicated function ***
-    bundler = DependencyBundler()
+    bundler = DependencyBundler(exclude_third_party=args.no_third_party)
     collected_source = bundler.run_dependency_analysis(initial_target_obj)
 
     # 4. Collate and Output

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pybundler',
-    version='0.1.0',
+    version='0.1.5',
     packages=find_packages(exclude=['tests*']),
     install_requires=[],  # Add any dependencies your project might have here
     author='Your Name',

--- a/tests/test_bundler.py
+++ b/tests/test_bundler.py
@@ -255,3 +255,27 @@ def test_function_with_third_party_dependency(fixture_paths):
         'UsageError'
     }
     assert all_found_qualnames == expected_qualnames
+
+
+def test_function_with_third_party_dependency_excluded(fixture_paths):
+    """Test that third-party dependencies are excluded when the flag is set."""
+    target_obj = load_target_function(fixture_paths['module_with_third_party_imports'],
+                                      "function_with_third_party_dependency")
+    assert target_obj is not None
+
+    # Enable the exclusion of third-party modules
+    bundler = DependencyBundler(exclude_third_party=True)
+    collected = bundler.run_dependency_analysis(target_obj)
+    collected_qualnames = get_collected_qualnames(collected)
+
+    # The only thing collected should be the target function itself,
+    # as its only dependency is a third-party module which should be excluded.
+    expected_qualnames = {
+        (fixture_paths['module_with_third_party_imports'], "function_with_third_party_dependency"),
+    }
+
+    assert collected_qualnames == expected_qualnames
+
+    # Explicitly check that no modules from 'site-packages' were included
+    for path, _ in collected.keys():
+        assert 'site-packages' not in path


### PR DESCRIPTION
This commit introduces a new command-line option `--no-third-party` that allows you to exclude third-party packages from the bundled output.

The implementation includes:
- A new CLI flag in `pybundler/main.py`.
- A new parameter in `DependencyBundler` to control the exclusion.
- A new function `is_third_party_module` in `pybundler/core_functions.py` to identify modules installed in `site-packages`.
- A new test case in `tests/test_bundler.py` to verify the new functionality.