### PR TITLE
Fix decorator discovery by inspecting function closures

### DIFF
--- a/tests/fixtures/module_with_complex_decorator.py
+++ b/tests/fixtures/module_with_complex_decorator.py
@@ -1,0 +1,24 @@
+class ComplexCommand:
+    """A mock command object similar to one created by a complex decorator."""
+    def __init__(self, callback):
+        self.callback = callback
+
+    def __call__(self, *args, **kwargs):
+        """Makes the object callable."""
+        return self.callback(*args, **kwargs)
+
+def complex_decorator(f):
+    """
+    A decorator that wraps a function in a ComplexCommand object,
+    simulating decorators like @click.command().
+    """
+    return ComplexCommand(f)
+
+def complex_dependency():
+    """A dependency for the complex decorated function."""
+    return "complex_dependency"
+
+@complex_decorator
+def complex_decorated_function():
+    """A function decorated with the complex decorator."""
+    return complex_dependency()

--- a/tests/fixtures/module_with_decorator.py
+++ b/tests/fixtures/module_with_decorator.py
@@ -1,0 +1,16 @@
+def simple_decorator(f):
+    """A simple decorator that wraps a function, but without functools.wraps."""
+    def wrapper(*args, **kwargs):
+        print("Decorator was here!")
+        return f(*args, **kwargs)
+    return wrapper
+
+def undecorated_dependency():
+    """A dependency for the decorated function."""
+    return "undecorated_dependency"
+
+@simple_decorator
+def decorated_function():
+    """A function that is decorated."""
+    print("I am a decorated function.")
+    return undecorated_dependency()

--- a/tests/fixtures/module_with_decorator_factory.py
+++ b/tests/fixtures/module_with_decorator_factory.py
@@ -1,0 +1,49 @@
+import functools
+
+class Command:
+    """A mock command object that holds a callback."""
+    def __init__(self, callback):
+        self.callback = callback
+
+    def __call__(self, *args, **kwargs):
+        """Makes the object callable, delegating to the callback."""
+        return self.callback(*args, **kwargs)
+
+def command_decorator(f):
+    """A decorator that wraps a function in a Command object."""
+    return Command(f)
+
+def decorator_factory(cli_obj):
+    """
+    A decorator factory that returns a decorator. This simulates a complex
+    scenario like `common_click_options` where a decorator is generated
+    and applies other decorators.
+    """
+    def inner_decorator(f):
+        # This wrapper function is decorated with @command_decorator,
+        # which turns it into a Command object.
+        @command_decorator
+        # It also uses @functools.wraps to preserve the metadata of the
+        # original function `f`.
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            """The innermost wrapper function."""
+            print(f"CLI object was: {cli_obj}")
+            return f(*args, **kwargs)
+        return wrapper
+    return inner_decorator
+
+def final_dependency():
+    """The final dependency that needs to be discovered."""
+    return "final_dependency"
+
+# This simulates a CLI group object.
+class CliGroup:
+    pass
+
+cli_group = CliGroup()
+
+@decorator_factory(cli_group)
+def top_level_function():
+    """The function decorated by the factory-generated decorator."""
+    return final_dependency()


### PR DESCRIPTION
When a function is decorated, especially without using `functools.wraps`, the bundler was failing to discover the original function and its dependencies. This was because the analysis was being performed on the wrapper function created by the decorator, and the link to the original function was only available through the wrapper's closure.

This commit fixes the issue by adding logic to inspect the `__closure__` attribute of function objects. If a function has a closure, the objects within it are added to the processing queue. This allows the bundler to find and analyze the original decorated function, ensuring its dependencies are correctly bundled.

The test suite has been updated to include a failing test case for this scenario, which now passes with the fix.